### PR TITLE
Add skip-images flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,8 @@ You can enable MPS acceleration by setting the `device-mode` parameter to `mps` 
 
 [Using MinerU via Command Line](https://mineru.readthedocs.io/en/latest/user_guide/usage/command_line.html)
 
+The CLI now supports a `--skip-images` flag to disable image and table cropping when you only need text content.
+
 > [!TIP]
 > For more information about the output files, please refer to the [Output File Description](docs/output_file_en_us.md).
 

--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ You can enable MPS acceleration by setting the `device-mode` parameter to `mps` 
 
 [Using MinerU via Command Line](https://mineru.readthedocs.io/en/latest/user_guide/usage/command_line.html)
 
-The CLI now supports a `--skip-images` flag to disable image and table cropping when you only need text content.
+The CLI now supports a `--skip-images` flag to disable image and table cropping when you only need text content. Images and tables will be preserved as `[IMAGE]` and `[TABLE]` placeholders in the output.
 
 > [!TIP]
 > For more information about the output files, please refer to the [Output File Description](docs/output_file_en_us.md).

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -490,7 +490,7 @@ pip install -U "magic-pdf[full]" -i https://mirrors.aliyun.com/pypi/simple
 
 [通过命令行使用MinerU](https://mineru.readthedocs.io/en/latest/user_guide/usage/command_line.html)
 
-现在命令行新增 `--skip-images` 选项，可在只需要文本内容时跳过图片和表格裁剪。
+现在命令行新增 `--skip-images` 选项，可在只需要文本内容时跳过图片和表格裁剪。输出结果会在原位置保留 `[IMAGE]` 与 `[TABLE]` 占位符。
 
 > [!TIP]
 > 更多有关输出文件的信息，请参考[输出文件说明](docs/output_file_zh_cn.md)

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -490,6 +490,8 @@ pip install -U "magic-pdf[full]" -i https://mirrors.aliyun.com/pypi/simple
 
 [通过命令行使用MinerU](https://mineru.readthedocs.io/en/latest/user_guide/usage/command_line.html)
 
+现在命令行新增 `--skip-images` 选项，可在只需要文本内容时跳过图片和表格裁剪。
+
 > [!TIP]
 > 更多有关输出文件的信息，请参考[输出文件说明](docs/output_file_zh_cn.md)
 

--- a/magic_pdf/dict2md/ocr_mkcontent.py
+++ b/magic_pdf/dict2md/ocr_mkcontent.py
@@ -84,6 +84,8 @@ def ocr_mk_markdown_with_para_core_v2(paras_of_layout,
                                     if span['type'] == ContentType.Image:
                                         if span.get('image_path', ''):
                                             para_text += f"![]({img_buket_path}/{span['image_path']})"
+                                        else:
+                                            para_text += "[IMAGE]"
                     for block in para_block['blocks']:  # 3rd.拼image_footnote
                         if block['type'] == BlockType.ImageFootnote:
                             para_text += '  \n' + merge_para_with_text(block)
@@ -95,6 +97,8 @@ def ocr_mk_markdown_with_para_core_v2(paras_of_layout,
                                     if span['type'] == ContentType.Image:
                                         if span.get('image_path', ''):
                                             para_text += f"![]({img_buket_path}/{span['image_path']})"
+                                        else:
+                                            para_text += "[IMAGE]"
                     for block in para_block['blocks']:  # 2nd.拼image_caption
                         if block['type'] == BlockType.ImageCaption:
                             para_text += '  \n' + merge_para_with_text(block)
@@ -115,6 +119,8 @@ def ocr_mk_markdown_with_para_core_v2(paras_of_layout,
                                         para_text += f"\n{span['html']}\n"
                                     elif span.get('image_path', ''):
                                         para_text += f"![]({img_buket_path}/{span['image_path']})"
+                                    else:
+                                        para_text += "[TABLE]"
                 for block in para_block['blocks']:  # 3rd.拼table_footnote
                     if block['type'] == BlockType.TableFootnote:
                         para_text += '\n' + merge_para_with_text(block) + '  '

--- a/magic_pdf/operators/models.py
+++ b/magic_pdf/operators/models.py
@@ -76,6 +76,7 @@ class InferenceResult(InferenceResultBase):
         end_page_id=None,
         debug_mode=False,
         lang=None,
+        process_images: bool = True,
     ) -> PipeResult:
         """Post-proc the model inference result, Extract the text using the
         third library, such as `pymupdf`
@@ -108,6 +109,7 @@ class InferenceResult(InferenceResultBase):
             end_page_id=end_page_id,
             debug_mode=debug_mode,
             lang=lang,
+            process_images=process_images,
         )
         return res
 
@@ -118,6 +120,7 @@ class InferenceResult(InferenceResultBase):
         end_page_id=None,
         debug_mode=False,
         lang=None,
+        process_images: bool = True,
     ) -> PipeResult:
         """Post-proc the model inference result, Extract the text using `OCR`
         technical.
@@ -150,5 +153,6 @@ class InferenceResult(InferenceResultBase):
             end_page_id=end_page_id,
             debug_mode=debug_mode,
             lang=lang,
+            process_images=process_images,
         )
         return res

--- a/magic_pdf/pdf_parse_union_core_v2.py
+++ b/magic_pdf/pdf_parse_union_core_v2.py
@@ -687,7 +687,14 @@ def remove_outside_spans(spans, all_bboxes, all_discarded_blocks):
 
 
 def parse_page_core(
-    page_doc: PageableData, magic_model, page_id, pdf_bytes_md5, imageWriter, parse_mode, lang
+    page_doc: PageableData,
+    magic_model,
+    page_id,
+    pdf_bytes_md5,
+    imageWriter,
+    parse_mode,
+    lang,
+    process_images: bool = True,
 ):
     need_drop = False
     drop_reason = []
@@ -854,7 +861,12 @@ def parse_page_core(
 
     """对image和table截图"""
     spans = ocr_cut_image_and_table(
-        spans, page_doc, page_id, pdf_bytes_md5, imageWriter
+        spans,
+        page_doc,
+        page_id,
+        pdf_bytes_md5,
+        imageWriter,
+        process_images=process_images,
     )
 
     """span填充进block"""
@@ -916,6 +928,7 @@ def pdf_parse_union(
     end_page_id=None,
     debug_mode=False,
     lang=None,
+    process_images: bool = True,
 ):
 
     pdf_bytes_md5 = compute_md5(dataset.data_bits())
@@ -953,7 +966,14 @@ def pdf_parse_union(
         """解析pdf中的每一页"""
         if start_page_id <= page_id <= end_page_id:
             page_info = parse_page_core(
-                page, magic_model, page_id, pdf_bytes_md5, imageWriter, parse_mode, lang
+                page,
+                magic_model,
+                page_id,
+                pdf_bytes_md5,
+                imageWriter,
+                parse_mode,
+                lang,
+                process_images=process_images,
             )
         else:
             page_info = page.get_page_info()

--- a/magic_pdf/pre_proc/cut_image.py
+++ b/magic_pdf/pre_proc/cut_image.py
@@ -5,22 +5,37 @@ from magic_pdf.libs.commons import join_path
 from magic_pdf.libs.pdf_image_tools import cut_image
 
 
-def ocr_cut_image_and_table(spans, page, page_id, pdf_bytes_md5, imageWriter):
+def ocr_cut_image_and_table(
+    spans, page, page_id, pdf_bytes_md5, imageWriter, process_images: bool = True
+):
     def return_path(type):
         return join_path(pdf_bytes_md5, type)
+
+    if not process_images:
+        return spans
 
     for span in spans:
         span_type = span['type']
         if span_type == ContentType.Image:
             if not check_img_bbox(span['bbox']) or not imageWriter:
                 continue
-            span['image_path'] = cut_image(span['bbox'], page_id, page, return_path=return_path('images'),
-                                           imageWriter=imageWriter)
+            span['image_path'] = cut_image(
+                span['bbox'],
+                page_id,
+                page,
+                return_path=return_path('images'),
+                imageWriter=imageWriter,
+            )
         elif span_type == ContentType.Table:
             if not check_img_bbox(span['bbox']) or not imageWriter:
                 continue
-            span['image_path'] = cut_image(span['bbox'], page_id, page, return_path=return_path('tables'),
-                                           imageWriter=imageWriter)
+            span['image_path'] = cut_image(
+                span['bbox'],
+                page_id,
+                page,
+                return_path=return_path('tables'),
+                imageWriter=imageWriter,
+            )
 
     return spans
 

--- a/magic_pdf/tools/cli.py
+++ b/magic_pdf/tools/cli.py
@@ -89,7 +89,14 @@ without method specified, auto will be used by default.""",
     help='The ending page for PDF parsing, beginning from 0.',
     default=None,
 )
-def cli(path, output_dir, method, lang, debug_able, start_page_id, end_page_id):
+@click.option(
+    '--skip-images',
+    'skip_images',
+    is_flag=True,
+    default=False,
+    help='Skip processing images and tables during parsing.',
+)
+def cli(path, output_dir, method, lang, debug_able, start_page_id, end_page_id, skip_images):
     os.makedirs(output_dir, exist_ok=True)
     temp_dir = tempfile.mkdtemp()
     def read_fn(path: Path):
@@ -127,7 +134,8 @@ def cli(path, output_dir, method, lang, debug_able, start_page_id, end_page_id):
                 debug_able,
                 start_page_id=start_page_id,
                 end_page_id=end_page_id,
-                lang=lang
+                lang=lang,
+                process_images=not skip_images,
             )
 
         except Exception as e:
@@ -150,7 +158,15 @@ def cli(path, output_dir, method, lang, debug_able, start_page_id, end_page_id):
                     doc_path = Path(fn)
                 doc_paths.append(doc_path)
         datasets = batch_build_dataset(doc_paths, 4, lang)
-        batch_do_parse(output_dir, [str(doc_path.stem) for doc_path in doc_paths], datasets, method, debug_able, lang=lang)
+        batch_do_parse(
+            output_dir,
+            [str(doc_path.stem) for doc_path in doc_paths],
+            datasets,
+            method,
+            debug_able,
+            lang=lang,
+            process_images=not skip_images,
+        )
     else:
         parse_doc(Path(path))
 

--- a/magic_pdf/tools/common.py
+++ b/magic_pdf/tools/common.py
@@ -91,6 +91,7 @@ def _do_parse(
     layout_model=None,
     formula_enable=None,
     table_enable=None,
+    process_images: bool = True,
 ):
     from magic_pdf.operators.models import InferenceResult
     if debug_able:
@@ -125,7 +126,10 @@ def _do_parse(
                         table_enable=table_enable,
                     )
                     pipe_result = infer_result.pipe_txt_mode(
-                        image_writer, debug_mode=True, lang=ds._lang
+                        image_writer,
+                        debug_mode=True,
+                        lang=ds._lang,
+                        process_images=process_images,
                     )
                 else:
                     infer_result = ds.apply(
@@ -137,7 +141,10 @@ def _do_parse(
                         table_enable=table_enable,
                     )
                     pipe_result = infer_result.pipe_ocr_mode(
-                        image_writer, debug_mode=True, lang=ds._lang
+                        image_writer,
+                        debug_mode=True,
+                        lang=ds._lang,
+                        process_images=process_images,
                     )
 
             elif parse_method == 'txt':
@@ -150,7 +157,10 @@ def _do_parse(
                     table_enable=table_enable,
                 )
                 pipe_result = infer_result.pipe_txt_mode(
-                    image_writer, debug_mode=True, lang=ds._lang
+                    image_writer,
+                    debug_mode=True,
+                    lang=ds._lang,
+                    process_images=process_images,
                 )
             elif parse_method == 'ocr':
                 infer_result = ds.apply(
@@ -162,7 +172,10 @@ def _do_parse(
                     table_enable=table_enable,
                 )
                 pipe_result = infer_result.pipe_ocr_mode(
-                    image_writer, debug_mode=True, lang=ds._lang
+                    image_writer,
+                    debug_mode=True,
+                    lang=ds._lang,
+                    process_images=process_images,
                 )
             else:
                 logger.error('unknown parse method')
@@ -175,20 +188,32 @@ def _do_parse(
         infer_result = InferenceResult(model_list, ds)
         if parse_method == 'ocr':
             pipe_result = infer_result.pipe_ocr_mode(
-                image_writer, debug_mode=True, lang=ds._lang
+                image_writer,
+                debug_mode=True,
+                lang=ds._lang,
+                process_images=process_images,
             )
         elif parse_method == 'txt':
             pipe_result = infer_result.pipe_txt_mode(
-                image_writer, debug_mode=True, lang=ds._lang
+                image_writer,
+                debug_mode=True,
+                lang=ds._lang,
+                process_images=process_images,
             )
         else:
             if ds.classify() == SupportedPdfParseMethod.TXT:
                 pipe_result = infer_result.pipe_txt_mode(
-                        image_writer, debug_mode=True, lang=ds._lang
+                        image_writer,
+                        debug_mode=True,
+                        lang=ds._lang,
+                        process_images=process_images,
                     )
             else:
                 pipe_result = infer_result.pipe_ocr_mode(
-                        image_writer, debug_mode=True, lang=ds._lang
+                        image_writer,
+                        debug_mode=True,
+                        lang=ds._lang,
+                        process_images=process_images,
                     )
 
 
@@ -266,6 +291,7 @@ def do_parse(
     layout_model=None,
     formula_enable=None,
     table_enable=None,
+    process_images: bool = True,
 ):
     parallel_count = 1
     if os.environ.get('MINERU_PARALLEL_INFERENCE_COUNT'):
@@ -279,9 +305,53 @@ def do_parse(
             ds = PymuDocDataset(pdf_bytes, lang=lang)
         else:
             ds = pdf_bytes_or_dataset
-        batch_do_parse(output_dir, [pdf_file_name], [ds], parse_method, debug_able, f_draw_span_bbox=f_draw_span_bbox, f_draw_layout_bbox=f_draw_layout_bbox, f_dump_md=f_dump_md, f_dump_middle_json=f_dump_middle_json, f_dump_model_json=f_dump_model_json, f_dump_orig_pdf=f_dump_orig_pdf, f_dump_content_list=f_dump_content_list, f_make_md_mode=f_make_md_mode, f_draw_model_bbox=f_draw_model_bbox, f_draw_line_sort_bbox=f_draw_line_sort_bbox, f_draw_char_bbox=f_draw_char_bbox, lang=lang)
+        batch_do_parse(
+            output_dir,
+            [pdf_file_name],
+            [ds],
+            parse_method,
+            debug_able,
+            f_draw_span_bbox=f_draw_span_bbox,
+            f_draw_layout_bbox=f_draw_layout_bbox,
+            f_dump_md=f_dump_md,
+            f_dump_middle_json=f_dump_middle_json,
+            f_dump_model_json=f_dump_model_json,
+            f_dump_orig_pdf=f_dump_orig_pdf,
+            f_dump_content_list=f_dump_content_list,
+            f_make_md_mode=f_make_md_mode,
+            f_draw_model_bbox=f_draw_model_bbox,
+            f_draw_line_sort_bbox=f_draw_line_sort_bbox,
+            f_draw_char_bbox=f_draw_char_bbox,
+            lang=lang,
+            process_images=process_images,
+        )
     else:
-        _do_parse(output_dir, pdf_file_name, pdf_bytes_or_dataset, model_list, parse_method, debug_able, start_page_id=start_page_id, end_page_id=end_page_id, lang=lang, layout_model=layout_model, formula_enable=formula_enable, table_enable=table_enable,  f_draw_span_bbox=f_draw_span_bbox, f_draw_layout_bbox=f_draw_layout_bbox, f_dump_md=f_dump_md, f_dump_middle_json=f_dump_middle_json, f_dump_model_json=f_dump_model_json, f_dump_orig_pdf=f_dump_orig_pdf, f_dump_content_list=f_dump_content_list, f_make_md_mode=f_make_md_mode, f_draw_model_bbox=f_draw_model_bbox, f_draw_line_sort_bbox=f_draw_line_sort_bbox, f_draw_char_bbox=f_draw_char_bbox)
+        _do_parse(
+            output_dir,
+            pdf_file_name,
+            pdf_bytes_or_dataset,
+            model_list,
+            parse_method,
+            debug_able,
+            start_page_id=start_page_id,
+            end_page_id=end_page_id,
+            lang=lang,
+            layout_model=layout_model,
+            formula_enable=formula_enable,
+            table_enable=table_enable,
+            f_draw_span_bbox=f_draw_span_bbox,
+            f_draw_layout_bbox=f_draw_layout_bbox,
+            f_dump_md=f_dump_md,
+            f_dump_middle_json=f_dump_middle_json,
+            f_dump_model_json=f_dump_model_json,
+            f_dump_orig_pdf=f_dump_orig_pdf,
+            f_dump_content_list=f_dump_content_list,
+            f_make_md_mode=f_make_md_mode,
+            f_draw_model_bbox=f_draw_model_bbox,
+            f_draw_line_sort_bbox=f_draw_line_sort_bbox,
+            f_draw_char_bbox=f_draw_char_bbox,
+            process_images=process_images,
+        )
 
 
 def batch_do_parse(
@@ -305,6 +375,7 @@ def batch_do_parse(
     layout_model=None,
     formula_enable=None,
     table_enable=None,
+    process_images: bool = True,
 ):
     dss = []
     for v in pdf_bytes_or_datasets:
@@ -334,6 +405,7 @@ def batch_do_parse(
             f_draw_line_sort_bbox=f_draw_line_sort_bbox,
             f_draw_char_bbox=f_draw_char_bbox,
             lang=lang,
+            process_images=process_images,
         )
 
 

--- a/projects/web_demo/web_demo/common/mk_markdown/mk_markdown.py
+++ b/projects/web_demo/web_demo/common/mk_markdown/mk_markdown.py
@@ -131,7 +131,10 @@ def ocr_mk_markdown_with_para_core_v2(paras_of_layout,
                         for line in block['lines']:
                             for span in line['spans']:
                                 if span['type'] == ContentType.Image:
-                                    para_text += f"\n![]({join_path(img_buket_path, span['image_path'])})  \n"
+                                    if span.get('image_path', ''):
+                                        para_text += f"\n![]({join_path(img_buket_path, span['image_path'])})  \n"
+                                    else:
+                                        para_text += "[IMAGE]"
                 for block in para_block['blocks']:  # 2nd.拼image_caption
                     if block['type'] == BlockType.ImageCaption:
                         para_text += merge_para_with_text(block)
@@ -155,8 +158,10 @@ def ocr_mk_markdown_with_para_core_v2(paras_of_layout,
                                         para_text += f"\n\n$\n {span['latex']}\n$\n\n"
                                     elif span.get('html', ''):
                                         para_text += f"\n\n{span['html']}\n\n"
-                                    else:
+                                    elif span.get('image_path', ''):
                                         para_text += f"\n![]({join_path(img_buket_path, span['image_path'])})  \n"
+                                    else:
+                                        para_text += "[TABLE]"
                 for block in para_block['blocks']:  # 3rd.拼table_footnote
                     if block['type'] == BlockType.TableFootnote:
                         para_text += merge_para_with_text(block)

--- a/tests/unittest/test_tools/test_cli.py
+++ b/tests/unittest/test_tools/test_cli.py
@@ -124,3 +124,31 @@ def test_cli_path():
 
     # teardown
     shutil.rmtree(temp_output_dir)
+
+
+def test_cli_skip_images():
+    unitest_dir = '/tmp/magic_pdf/unittest/tools'
+    os.makedirs(unitest_dir, exist_ok=True)
+    temp_output_dir = tempfile.mkdtemp(dir=unitest_dir)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            '-p',
+            'tests/unittest/test_tools/assets/cli/pdf/cli_test_01.pdf',
+            '-o',
+            temp_output_dir,
+            '--skip-images',
+        ],
+    )
+
+    assert result.exit_code == 0
+
+    base_output_dir = os.path.join(temp_output_dir, 'cli_test_01/auto')
+    middle_path = os.path.join(base_output_dir, 'cli_test_01_middle.json')
+    with open(middle_path, 'r') as f:
+        data = f.read()
+        assert 'image_path' not in data
+
+    shutil.rmtree(temp_output_dir)

--- a/tests/unittest/test_tools/test_cli.py
+++ b/tests/unittest/test_tools/test_cli.py
@@ -151,4 +151,9 @@ def test_cli_skip_images():
         data = f.read()
         assert 'image_path' not in data
 
+    md_path = os.path.join(base_output_dir, 'cli_test_01.md')
+    with open(md_path, 'r') as f:
+        md_data = f.read()
+        assert '[IMAGE]' in md_data
+
     shutil.rmtree(temp_output_dir)


### PR DESCRIPTION
## Summary
- make `ocr_cut_image_and_table` optionally skip cutting images
- plumb `process_images` argument through pdf parsing pipeline
- support disabling image processing in API and CLI
- document `--skip-images` flag in README
- test CLI without image extraction

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684a4910645c8330b0d00468480906db